### PR TITLE
Addressing notes

### DIFF
--- a/enctests/README.md
+++ b/enctests/README.md
@@ -16,10 +16,14 @@ usage: main.py [-h] [--source-folder SOURCE_FOLDER] [--test-config-dir TEST_CONF
 
 optional arguments:
   -h, --help            show this help message and exit
+  --sources SOURCES [SOURCES ...]
+                        Provide a list of paths to sources in stead of running all from source folder. Please note this overrides the --source-folder argument.
   --source-folder SOURCE_FOLDER
                         Where to look for source media files
   --test-config-dir TEST_CONFIG_DIR
                         Where to look for *.yml files containing test descriptions
+  --test-config TEST_CONFIG_FILE
+                        Specify a single test config file to run
   --prep-sources        Create *.yml files from media in --source-folder used as sources in encoding tests
   --encoded-folder ENCODED_FOLDER
                         Where to store the encoded files
@@ -98,6 +102,29 @@ test_colorspace_yuv420p:
             -color_range: 2
             -color_trc: 1
 ---
+```
+
+#### Additional options in the test config
+You may provide a list of sources in a test config. Please note that this will 
+override the behavior of the `--source-folder` argument. Only the sources 
+provided in the test config will be used in the tests.
+
+Example:
+```yaml
+---
+test_colorspace_yuv420p:
+    name: test_colorspace_yuv420p
+    description: variations of colorspace yuv420p
+    app: ffmpeg
+    suffix: .mov
+    encoding_template: 'ffmpeg {input_args} -i "{source}" -vframes {duration} {encoding_args} -y "{outfile}"'
+    sources:
+      - sources/Sintel-trailer-1080p-png/1080p/sintel_trailer_2k_%04d.png.yml
+    wedges:
+        slow_crf_23: &base_args
+            -c:v: libx264
+            -preset: slow
+            -crf: 23
 ```
 
 ### Run the tests

--- a/enctests/testframework/encoders/base.py
+++ b/enctests/testframework/encoders/base.py
@@ -12,6 +12,7 @@ class ABCTestEncoder(ABC):
             test_config: dict,
             destination: pathlib.Path
     ):
+        self._application_version = None
         self.source_clip = source_clip
         self.test_config = test_config
         self.destination = destination
@@ -25,4 +26,7 @@ class ABCTestEncoder(ABC):
 
     @abstractmethod
     def get_application_version(self) -> str:
-        """Return version of encoder application"""
+        """Return version of encoder application
+        You should cache the application version in the
+        self._application_version variable
+        """

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -28,9 +28,11 @@ class FFmpegEncoder(ABCTestEncoder):
             test_config: dict,
             destination: pathlib.Path
     ):
-        self.source_clip = source_clip
-        self.test_config = test_config
-        self.destination = destination
+        super(FFmpegEncoder, self).__init__(
+            source_clip,
+            test_config,
+            destination
+        )
 
     def run_wedges(self) -> dict:
         # The results dictionary is passed to source clip's list of available
@@ -86,11 +88,14 @@ class FFmpegEncoder(ABCTestEncoder):
         return results
 
     def get_application_version(self) -> str:
-        cmd = f'ffmpeg -version -v quiet -hide_banner'
-        _raw = subprocess.check_output(shlex.split(cmd))
-        version = b'_'.join(_raw.split(b' ')[:3])
+        if not self._application_version:
+            cmd = f'ffmpeg -version -v quiet -hide_banner'
+            _raw = subprocess.check_output(shlex.split(cmd))
+            version = b'_'.join(_raw.split(b' ')[:3])
 
-        return str(version, 'utf-8')
+            self._application_version = str(version, 'utf-8')
+
+        return self._application_version
 
     def prep_encoding_command(self, wedge: dict, out_file: pathlib.Path) -> str:
         template = self.test_config.get('encoding_template')

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -67,20 +67,14 @@ class FFmpegEncoder(ABCTestEncoder):
             mr = create_media_reference(out_file, self.source_clip)
 
             # Update metadata for use later
-            ffmpeg_version = self.get_application_version()
-            # encoding_args = ' '.join(
-            #     [f'{key} {value}' for key, value in wedge.items()]
-            # )
-
             # !! Use this function from utils to make sure we find the metadata
             # later on
-            enc_meta = get_test_metadata_dict(mr, test_name)
-
-            test_meta = enc_meta.setdefault(ffmpeg_version, {})
-            test_meta['encode_time'] = round(enctime, 4)
-            # test_meta['encode_arguments'] = encoding_args
+            test_meta = get_test_metadata_dict(mr)
             test_meta['encode_arguments'] = wedge
-            test_meta['filesize'] = out_file.stat().st_size
+
+            result_meta = test_meta.setdefault('results', {})
+            result_meta['encode_time'] = round(enctime, 4)
+            result_meta['filesize'] = out_file.stat().st_size
 
             # Add media reference to result list
             results.update({test_name: mr})

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -66,9 +66,9 @@ class FFmpegEncoder(ABCTestEncoder):
 
             # Update metadata for use later
             ffmpeg_version = self.get_application_version()
-            encoding_args = ' '.join(
-                [f'{key} {value}' for key, value in wedge.items()]
-            )
+            # encoding_args = ' '.join(
+            #     [f'{key} {value}' for key, value in wedge.items()]
+            # )
 
             # !! Use this function from utils to make sure we find the metadata
             # later on
@@ -76,7 +76,8 @@ class FFmpegEncoder(ABCTestEncoder):
 
             test_meta = enc_meta.setdefault(ffmpeg_version, {})
             test_meta['encode_time'] = round(enctime, 4)
-            test_meta['encode_arguments'] = encoding_args
+            # test_meta['encode_arguments'] = encoding_args
+            test_meta['encode_arguments'] = wedge
             test_meta['filesize'] = out_file.stat().st_size
 
             # Add media reference to result list

--- a/enctests/testframework/encoders/ffmpeg_encoder.py
+++ b/enctests/testframework/encoders/ffmpeg_encoder.py
@@ -77,7 +77,7 @@ class FFmpegEncoder(ABCTestEncoder):
             test_meta = enc_meta.setdefault(ffmpeg_version, {})
             test_meta['encode_time'] = round(enctime, 4)
             test_meta['encode_arguments'] = encoding_args
-            test_meta['filesize'] = sizeof_fmt(out_file)
+            test_meta['filesize'] = out_file.stat().st_size
 
             # Add media reference to result list
             results.update({test_name: mr})

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -271,11 +271,16 @@ model=path={vmaf_model}\" \
 
     results = {
         'vmaf': raw_results['pooled_metrics'].get('vmaf'),
-        'psnr': raw_results['pooled_metrics'].get('psnr')
+        'psnr': raw_results['pooled_metrics'].get('psnr')   # FFmpeg < 5.1
     }
 
-    enc_meta = get_test_metadata_dict(test_ref, testname)
-    enc_meta['results'] = results
+    # FFmpeg >= 5.1 have split psnr results
+    if not results['psnr']:
+        for key in ['psnr_y', 'psnr_cb', 'psnr_cr']:
+            results[key] = raw_results['pooled_metrics'].get(key)
+
+    enc_meta = get_test_metadata_dict(test_ref)
+    enc_meta['results'].update(results)
 
 
 def prep_sources(args):

--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -57,7 +57,8 @@ def parse_args():
         nargs='+',
         default=[],
         help='Provide a list of paths to sources in stead of running all '
-             'from source folder'
+             'from source folder. '
+             'Please note this overrides the --source-folder argument.'
     )
 
     parser.add_argument(
@@ -318,7 +319,6 @@ def run_tests(args, test_configs, timeline):
     # Check for sources in test configs
     test_sources = check_for_sources(test_configs)
     args.sources = args.sources or test_sources
-    print(args.sources)
 
     # Prepare sources for tests
     source_bin = prep_sources(args)

--- a/enctests/testframework/utils/utils.py
+++ b/enctests/testframework/utils/utils.py
@@ -154,11 +154,10 @@ def create_media_reference(path, source_clip, is_sequence=False):
     return mr
 
 
-def get_test_metadata_dict(otio_clip, testname):
+def get_test_metadata_dict(otio_clip):
     aswf_meta = otio_clip.metadata.setdefault('aswf_enctests', {})
-    enc_meta = aswf_meta.setdefault(testname, {})
 
-    return enc_meta
+    return aswf_meta
 
 
 def get_source_metadata_dict(source_clip):


### PR DESCRIPTION
This PR includes the following:

**BREAKING CHANGE:**
* Test results for each version of FFmpeg get stored in their own track. Therefore this PR reorganizes the results metadata removing a few redundant levels. Should be simpler to traverse.

**OTHER:** 
* Store encoded file sizes in bytes and not pretty formatted sizes for better graphing
* Store encoding arguments as pure dict and not resolved string. A step towards resolving #11
* Add `--sources` argument which overrides the sources found in `--source-folder`
* Optionally override sources tested via the test config under a "sources" key. Closes #12 
* Fixed "psnr" results not added to metadata. Looks like the results from ffmpeg changed in 5.1. Closes #16 
