### PR TITLE
This forces the vmaf comparison colorspace, otherwise its assume the …

### DIFF
--- a/enctests/testframework/main.py
+++ b/enctests/testframework/main.py
@@ -225,6 +225,8 @@ def tests_only(test_configs):
 def vmaf_compare(source_clip, test_ref, testname):
     vmaf_cmd = '\
 {ffmpeg_bin} \
+-color_primaries bt709 \
+ -colorspace bt709 \
 {reference} \
 -i "{distorted}" \
 -vframes {duration} \


### PR DESCRIPTION
…source colorspace is rec601 (I think).

I'm not 100% sure we want to do it this way, but I'm pretty sure this is wrong since otherwise ffmpeg will treat any sourceimages as having the wrong colorspace.